### PR TITLE
Fix OpenSSL compatibility issue with Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This will create a speech file at the specified path.
 
 ## Addressing OpenSSL Error
 
-
+### On Unix
 
 ```bash
 export NODE_OPTIONS=--openssl-legacy-provider

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "openai-tts",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+  "scripts": {
+    "start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
+    "test": "NODE_OPTIONS=--openssl-legacy-provider react-scripts test",
     "eject": "react-scripts eject"
   },
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3"
-  },
-
+  }
 }


### PR DESCRIPTION
Address the OpenSSL compatibility issue with Node.js.

* **README.md**
  - Add instructions to set the `NODE_OPTIONS` environment variable to `--openssl-legacy-provider` for Unix environments.

* **package.json**
  - Add `NODE_OPTIONS=--openssl-legacy-provider` to the `start` script.
  - Add `NODE_OPTIONS=--openssl-legacy-provider` to the `build` script.
  - Add `NODE_OPTIONS=--openssl-legacy-provider` to the `test` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=b1963a8e-ae71-4c11-87f3-43aef9a84a55).