### PR TITLE
Add input for OpenAI key in web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,13 @@ The Android metal style provides a modern and sleek look to the web UI, enhancin
 ## Server Response
 
 Ensure that the server handling the `/tts` endpoint returns a JSON response. This will prevent errors such as "Unexpected token '<', "<!DOCTYPE "... is not valid JSON" from occurring when the server response is HTML instead of JSON.
+
+## Entering the OpenAI Key in the Web UI
+
+To use the OpenAI key in the web UI, follow these steps:
+
+1. Open the application in your web browser.
+2. Enter your OpenAI key in the input field labeled "Enter OpenAI Key".
+3. Enter the text you want to convert to speech in the input field labeled "Enter text".
+4. Click the "Submit" button to send the request to the server.
+5. The server will process the request and return the speech file, which you can download from the provided link.

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import TTSForm from './components/TTSForm';
 
 function App() {
+  const [openaiKey, setOpenaiKey] = useState('');
+
   return (
     <div className="App android-metal-container">
       <header className="App-header android-metal-header">
         <h1>Text to Speech</h1>
       </header>
       <main>
-        <TTSForm />
+        <TTSForm openaiKey={openaiKey} setOpenaiKey={setOpenaiKey} />
       </main>
     </div>
   );

--- a/src/components/TTSForm.js
+++ b/src/components/TTSForm.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-function TTSForm() {
+function TTSForm({ openaiKey }) {
   const [text, setText] = useState('');
   const [speechFile, setSpeechFile] = useState(null);
   const [errorMessage, setErrorMessage] = useState('');
@@ -19,6 +19,7 @@ function TTSForm() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${openaiKey}`,
         },
         body: JSON.stringify({ text }),
       });
@@ -55,6 +56,16 @@ function TTSForm() {
           value={text}
           onChange={(e) => setText(e.target.value)}
           className="android-metal-textarea"
+        />
+        <br />
+        <label htmlFor="openaiKey" className="android-metal-label">Enter OpenAI Key:</label>
+        <input
+          type="text"
+          id="openaiKey"
+          name="openaiKey"
+          value={openaiKey}
+          onChange={(e) => setOpenaiKey(e.target.value)}
+          className="android-metal-input"
         />
         <br />
         <button type="submit" className="android-metal-button">Submit</button>


### PR DESCRIPTION
Add input field for OpenAI key in the web UI and update related components.

* **src/components/TTSForm.js**
  - Add a new state variable `openaiKey` to store the OpenAI key.
  - Add an input field for the OpenAI key in the form.
  - Include the OpenAI key in the API call to `/tts`.

* **src/App.js**
  - Add a new state variable `openaiKey` to store the OpenAI key.
  - Pass the `openaiKey` state variable as a prop to `TTSForm`.

* **README.md**
  - Add instructions for entering the OpenAI key in the web UI.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=d76582d2-9b7f-49e6-831f-46c5f71aed58).