### PR TITLE
Upgrade web components and improve UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
   }
 }

--- a/src/components/TTSForm.js
+++ b/src/components/TTSForm.js
@@ -66,6 +66,7 @@ function TTSForm({ openaiKey }) {
           value={openaiKey}
           onChange={(e) => setOpenaiKey(e.target.value)}
           className="android-metal-input"
+          maxLength="256"
         />
         <br />
         <button type="submit" className="android-metal-button">Submit</button>


### PR DESCRIPTION
Upgrade the web components to the latest version and increase the input area for the OpenAI key input to allow 256 characters.

* **Dependencies**
  - Upgrade `react` to version `18.2.0`
  - Upgrade `react-dom` to version `18.2.0`
  - Upgrade `react-scripts` to version `5.0.1`

* **Input Field**
  - Increase the `maxLength` attribute of the OpenAI key input field to 256 characters in `src/components/TTSForm.js`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=0e6aa846-7731-4940-8d57-91d122a3446b).