### PR TITLE
Fix setOpenaiKey error in TTSForm component

### DIFF
--- a/src/components/TTSForm.js
+++ b/src/components/TTSForm.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-function TTSForm({ openaiKey }) {
+function TTSForm({ openaiKey, setOpenaiKey }) {
   const [text, setText] = useState('');
   const [speechFile, setSpeechFile] = useState(null);
   const [errorMessage, setErrorMessage] = useState('');


### PR DESCRIPTION
Add `setOpenaiKey` to the `TTSForm` component parameters.

* Update the `onChange` event handler to use `setOpenaiKey`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=98909b75-245f-4406-a35f-f86bcaef7fc8).