### PR TITLE
Update the project to use Jekyll for the GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Build project
-        run: npm run build
-
       - name: Set up Personal Access Token
         run: echo "MY_GITHUB_TOKEN=${{ secrets.MY_GITHUB_TOKEN }}" >> $GITHUB_ENV
 
@@ -34,8 +31,14 @@ jobs:
             exit 1
           fi
 
+      - name: Install Jekyll
+        run: sudo gem install jekyll bundler
+
+      - name: Build Jekyll site
+        run: jekyll build
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.MY_GITHUB_TOKEN }}
-          publish_dir: ./build
+          publish_dir: ./_site

--- a/README.md
+++ b/README.md
@@ -17,10 +17,22 @@ cd openai-tts
 npm install
 ```
 
-## Running the Next.js Application
+## Building and Deploying the Jekyll Site
+
+To build and deploy the Jekyll site, follow these steps:
+
+1. Install Jekyll and Bundler:
 
 ```bash
-npm run dev
+gem install jekyll bundler
 ```
 
-2. Open your web browser and navigate to `http://localhost:3000` to see the application in action.
+2. Build the Jekyll site:
+
+```bash
+jekyll build
+```
+
+3. Deploy the site to GitHub Pages:
+
+The deployment is handled automatically by the GitHub Actions workflow defined in `.github/workflows/deploy.yml`. Simply push your changes to the `main` branch, and the site will be built and deployed to GitHub Pages.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,4 @@
+title: "OpenAI TTS"
+description: "A project to convert text to speech using OpenAI."
+baseurl: "/openai-tts"
+theme: minima


### PR DESCRIPTION
Update the project to use Jekyll for GitHub Pages deployment.

* **README.md**: Add instructions for building and deploying the Jekyll site. Remove instructions for running the Next.js application.
* **_config.yml**: Add Jekyll configuration with `title`, `description`, `baseurl`, and set `theme` to `minima`.
* **.github/workflows/deploy.yml**: Remove `npm run build` step. Add steps to install Jekyll and build the Jekyll site. Update `publish_dir` to `_site`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=68f39d49-6153-439e-a79f-26f88273ccfc).