### PR TITLE
Fix OpenAI Configuration error in text-to-speech API

### DIFF
--- a/pages/api/text-to-speech.js
+++ b/pages/api/text-to-speech.js
@@ -17,8 +17,8 @@ export default async function handler(req, res) {
   const openai = new OpenAIApi(configuration);
 
   try {
-    const response = await openai.createSpeech({
-      model: "tts-1",
+    const response = await openai.createTranscription({
+      model: "whisper-1",
       input: text,
       voice: "alloy", // You can explore other voices
       response_format: "mp3",


### PR DESCRIPTION
Fix the TypeError in `pages/api/text-to-speech.js`.

* Update the `createSpeech` method to `createTranscription`.
* Update the `model` parameter to `whisper-1`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=949c6855-57b2-43aa-a61b-094bc43e1b51).