### PR TITLE
Fix `rescue in gemspec`: The minima theme could not be found

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "minima"


### PR DESCRIPTION
Add `minima` theme as a dependency in the `Gemfile`.

* Add `gem "minima"` to include the `minima` theme as a dependency

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=8b610e1d-7a79-4824-9c5f-3b934268130a).