### PR TITLE
Fix GitHub Actions deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install Jekyll
         run: sudo gem install jekyll bundler
 
+      - name: Install Bundler dependencies
+        run: bundle install
+
       - name: Build Jekyll site
         run: jekyll build
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gem "minima"
+gem "jekyll"
+gem "bundler"


### PR DESCRIPTION
Add necessary steps to fix the GitHub Actions deployment issue.

* Add `gem "jekyll"` and `gem "bundler"` to the `Gemfile` to ensure Jekyll and Bundler are installed.
* Modify `.github/workflows/deploy.yml` to include a step to run `bundle install` before the `jekyll build` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=9f4712c7-9122-4647-af40-9f23de86910c).