### PR TITLE
Fix rake dependency issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install Jekyll
         run: sudo gem install jekyll bundler
 
+      - name: Update rake gem
+        run: sudo gem update rake
+
       - name: Install Bundler dependencies
         run: bundle install
 


### PR DESCRIPTION
Add a step to update the `rake` gem before running `bundle install` in the GitHub Actions workflow.

* **Update rake gem**
  - Add a step to update the `rake` gem using `sudo gem update rake` before installing Bundler dependencies in `.github/workflows/deploy.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=67444445-cdd8-4a17-b276-88f64bf7afb6).