### PR TITLE
Fix GitHub Pages deployment for Next.js application

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,20 +31,11 @@ jobs:
             exit 1
           fi
 
-      - name: Install Jekyll
-        run: sudo gem install jekyll bundler
-
-      - name: Update rake gem
-        run: sudo gem update rake
-
-      - name: Install Bundler dependencies
-        run: sudo bundle install
-
-      - name: Build Jekyll site
-        run: sudo jekyll build
+      - name: Build Next.js application
+        run: npm run build
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.MY_GITHUB_TOKEN }}
-          publish_dir: ./_site
+          publish_dir: ./out

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 title: "OpenAI TTS"
 description: "A project to convert text to speech using OpenAI."
-baseurl: "/openai-tts"
+baseurl: ""
 theme: minima

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OpenAI TTS</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="/_next/static/chunks/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Add `index.html` file and modify deployment workflow for GitHub Pages compatibility.

* **Add `index.html` file**
  - Create `pages/index.html` with basic HTML structure, title, and root div for React app
  - Add script tag to load Next.js application

* **Modify deployment workflow**
  - Change `.github/workflows/deploy.yml` to build Next.js application instead of Jekyll site
  - Update `publish_dir` to point to Next.js build output directory

* **Update `_config.yml`**
  - Change `baseurl` to be compatible with Next.js application

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=ce620473-dcc1-4174-bffd-7f6c5254f0c8).