### PR TITLE
Fix build process by updating Node.js version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16
 
 ARG USER=vscode
 ARG DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
Update Node.js version to 16 to resolve build issues.

* **.devcontainer/Dockerfile**
  - Change the base image from `node:14` to `node:16`.

* **.github/workflows/deploy.yml**
  - Update the `node-version` from `14` to `16` in the `Set up Node.js` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=6651f569-8544-4b85-a02d-41418c7f6c95).