### PR TITLE
Fix deploy script to create out directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build Next.js application
         run: sudo npm run build
 
+      - name: Create out directory
+        run: mkdir -p ./out
+
       - name: Copy index.html to root directory
         run: sudo cp pages/index.html ./out/index.html
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "prebuild": "mkdir -p ./out"
   },
   "dependencies": {
     "next": "15.0.1",


### PR DESCRIPTION
Add a step to create the `./out` directory before copying `index.html` in the GitHub Actions workflow.

* **package.json**
  - Add a `prebuild` script to create the `./out` directory before building.

* **.github/workflows/deploy.yml**
  - Add a step to create the `./out` directory before copying the `index.html` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=c038e074-8d21-4ef9-81c1-4ce4aef466cd).