### PR TITLE
Fix build log creation and usage in build-report.yml

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -22,8 +22,11 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Create empty build log
+        run: touch build.log
+
       - name: Run build
-        run: npm run build
+        run: npm run build > build.log 2>&1
 
       - name: Calculate build success and failure rates
         id: calculate-rates

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://dwaynehelena.github.io/openai-tts/",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build > build.log 2>&1",
     "start": "next start",
     "prebuild": "mkdir -p ./out"
   },


### PR DESCRIPTION
Add build log creation and redirection to `build.log` in build process.

* **package.json**
  - Modify the `build` script to redirect output to `build.log`.

* **.github/workflows/build-report.yml**
  - Add a step to create an empty `build.log` file before running the build.
  - Modify the `Run build` step to redirect output to `build.log`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=4dd2a5ea-cfe0-4707-8e18-2200e31999cb).