### PR TITLE
Fix TypeError in actions/github-script@v6

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -44,6 +44,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const github = require('@actions/github');
+            const context = github.context;
             const { SUCCESS_RATE, FAILURE_RATE } = process.env;
             const comment = `Build Success Rate: ${SUCCESS_RATE}%\nBuild Failure Rate: ${FAILURE_RATE}%`;
             github.issues.createComment({


### PR DESCRIPTION
Fix the TypeError in the `actions/github-script@v6` action in the `.github/workflows/build-report.yml` workflow.

* Import `@actions/github` at the top of the script section in the `Post build report as PR comment` step.
* Initialize `github` and `context` objects using `@actions/github` in the script section.
* Update the script to use the initialized `github` and `context` objects.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/openai-tts?shareId=9c7c112a-91a0-45c2-aa7f-16828254a3a9).